### PR TITLE
Update user account name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,46 @@
+# v2.7.0
+
+Reaction v2.7.0 adds performance enhancements and fixes bugs.
+
+This release is being coordinated with [Reaction Platform](https://github.com/reactioncommerce/reaction-platform) and is designed to work with `v2.7.0` of [Reaction Hydra](https://github.com/reactioncommerce/reaction-hydra) and [Example Storefront](https://github.com/reactioncommerce/example-storefront).
+
+## Notable changes
+
+### More packages have continued to migrate from `no-meteor` folders to `node-app`
+
+As part of de-meteorization of the Reaction API, We have continued the migration of moving all server side code in `no-meteor` folders to their respective `node-app` folders.
+
+## Fixes
+
+- fix: pass correct userId when creating a shop ([#5694](https://github.com/reactioncommerce/reaction/pull/5694))
+- fix: filter products by file on Windows ([#5700](https://github.com/reactioncommerce/reaction/pull/5700))
+
+## Refactors
+
+- refactor: Move accounts plugin to Node app and better split accounts from users/IDP ([#5693](https://github.com/reactioncommerce/reaction/pull/5693))
+- refactor: clean-up tasks related to removing `appEvents` from all meteor code ([#5692](https://github.com/reactioncommerce/reaction/pull/5692))
+- refactor: clean-up tasks related to moving files to the node-app ([#5688](https://github.com/reactioncommerce/reaction/pull/5688))
+- refactor: simpleSchema updates for mockContext ([#5685](https://github.com/reactioncommerce/reaction/pull/5685))
+- refactor: move getPaymentMethodConfigByName to context ([#5684](https://github.com/reactioncommerce/reaction/pull/5684))
+- refactor: create `archiveProducts` GQL mutation to replace meteor methods ([#5680](https://github.com/reactioncommerce/reaction/pull/5680))
+- refactor: move jobs-queue from server/no-meteor to node-app ([#5678(https://github.com/reactioncommerce/reaction/pull/5678))
+- refactor: move cart from server/no-meteor to node-app ([#5675](https://github.com/reactioncommerce/reaction/pull/5675))
+- refactor: move checkout from server/no-meteor to node-app ([#5674](https://github.com/reactioncommerce/reaction/pull/5674))
+- refactor: move core plugin to Node app ([#5673](https://github.com/reactioncommerce/reaction/pull/5673))
+- refactor: move discounts plugins to Node app ([#5672](https://github.com/reactioncommerce/reaction/pull/5672))
+- refactor: move marketplace to Node app ([#5671](https://github.com/reactioncommerce/reaction/pull/5671))
+- refactor: move orders from server/no-meteor to node-app ([#5670](https://github.com/reactioncommerce/reaction/pull/5670))
+- refactor: move catalog from server/no-meteor to node-app ([#5658](https://github.com/reactioncommerce/reaction/pull/5658))
+- refactor: move navigation from server/no-meteor to node-app ([#5656](https://github.com/reactioncommerce/reaction/pull/5656))
+- refactor: move email from server/no-meteor to node-app ([#5655](https://github.com/reactioncommerce/reaction/pull/5655))
+- refactor: move i18n from server/no-meteor to node-app ([#5654](https://github.com/reactioncommerce/reaction/pull/5654))
+- refactor: move product and product-variant from server/no-meteor to node-app ([#5669](https://github.com/reactioncommerce/reaction/pull/5669))
+- refactor: move sitemap-generator from server/no-meteor to node-app ([#5667](https://github.com/reactioncommerce/reaction/pull/5667))
+- refactor: move Tags from server/no-meteor to node-app ([#5665](https://github.com/reactioncommerce/reaction/pull/5665))
+- refactor: move dashboard from server/no-meteor to node-app ([#5663](https://github.com/reactioncommerce/reaction/pull/5663))
+- refactor: move product-admin plugin to Node app ([#5659](https://github.com/reactioncommerce/reaction/pull/5659))
+- refactor: move notifications plugin to Node app ([#5661](https://github.com/reactioncommerce/reaction/pull/5661))
+
 # v2.6.0
 
 Reaction v2.6.0 adds minor features and performance enhancements, fixes bugs and contains no breaking changes since v2.6.0.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ As part of de-meteorization of the Reaction API, We have continued the migration
 - refactor: simpleSchema updates for mockContext ([#5685](https://github.com/reactioncommerce/reaction/pull/5685))
 - refactor: move getPaymentMethodConfigByName to context ([#5684](https://github.com/reactioncommerce/reaction/pull/5684))
 - refactor: create `archiveProducts` GQL mutation to replace meteor methods ([#5680](https://github.com/reactioncommerce/reaction/pull/5680))
-- refactor: move jobs-queue from server/no-meteor to node-app ([#5678(https://github.com/reactioncommerce/reaction/pull/5678))
+- refactor: move jobs-queue from server/no-meteor to node-app ([#5678](https://github.com/reactioncommerce/reaction/pull/5678))
 - refactor: move cart from server/no-meteor to node-app ([#5675](https://github.com/reactioncommerce/reaction/pull/5675))
 - refactor: move checkout from server/no-meteor to node-app ([#5674](https://github.com/reactioncommerce/reaction/pull/5674))
 - refactor: move core plugin to Node app ([#5673](https://github.com/reactioncommerce/reaction/pull/5673))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ This release is being coordinated with [Reaction Platform](https://github.com/re
 
 As part of de-meteorization of the Reaction API, We have continued the migration of moving all server side code in `no-meteor` folders to their respective `node-app` folders.
 
+### Potential Breaking Changes for Custom Plugins
+
+There might be breaking changes in custom plugins due to the movement of core packages to the `node-app` folders. Custom plugins will need to update their imports paths to reflect the new location of packages.
+
 ## Fixes
 
 - fix: pass correct userId when creating a shop ([#5694](https://github.com/reactioncommerce/reaction/pull/5694))

--- a/imports/node-app/core-services/account/mutations/index.js
+++ b/imports/node-app/core-services/account/mutations/index.js
@@ -9,6 +9,7 @@ import sendResetAccountPasswordEmail from "./sendResetAccountPasswordEmail.js";
 import setAccountProfileCurrency from "./setAccountProfileCurrency.js";
 import setAccountProfileLanguage from "./setAccountProfileLanguage.js";
 import updateAccountAddressBookEntry from "./updateAccountAddressBookEntry.js";
+import updateAccountName from "./updateAccountName";
 
 export default {
   addressBookAdd,
@@ -21,5 +22,6 @@ export default {
   sendResetAccountPasswordEmail,
   setAccountProfileCurrency,
   setAccountProfileLanguage,
-  updateAccountAddressBookEntry
+  updateAccountAddressBookEntry,
+  updateAccountName
 };

--- a/imports/node-app/core-services/account/mutations/updateAccountName.js
+++ b/imports/node-app/core-services/account/mutations/updateAccountName.js
@@ -1,0 +1,59 @@
+import SimpleSchema from "simpl-schema";
+import ReactionError from "@reactioncommerce/reaction-error";
+
+const inputSchema = new SimpleSchema({
+  name: String,
+  accountId: {
+    type: String,
+    optional: true
+  }
+});
+
+/**
+ * @name accounts/updateAccountName
+ * @memberof Mutations/Accounts
+ * @summary Updates users profile name
+ * @param {Object} context - GraphQL execution context
+ * @param {Object} input - Necessary input for mutation. See SimpleSchema.
+ * @param {String} input.name - name to update on the user profile
+ * @param {String} [input.accountId] - optional decoded ID of account on which entry should be updated, for admin
+ * @returns {Promise<Object>} with updated name
+ */
+export default async function updateAccountName(context, input) {
+  inputSchema.validate(input);
+  const { appEvents, collections, userHasPermission, userId: userIdFromContext } = context;
+  const { Accounts, Shops } = collections;
+  const { name, accountId: providedAccountId } = input;
+
+  const accountId = providedAccountId || userIdFromContext;
+  if (!accountId) throw new ReactionError("access-denied", "You must be logged in to set profile name");
+
+  const account = await Accounts.findOne({ _id: accountId }, { projection: { shopId: 1 } });
+  if (!account) throw new ReactionError("not-found", "No account found");
+
+  if (!context.isInternalCall && userIdFromContext !== providedAccountId) {
+    if (!userHasPermission(["reaction-accounts"], account.shopId)) throw new ReactionError("access-denied", "Access denied");
+  }
+
+  const names = name.split(" ");
+
+  const { value: updatedAccount } = await Accounts.findOneAndUpdate({
+    _id: accountId
+  }, {
+    $set: {
+      "profile.name": name,
+      "profile.firstName": names[0],
+      "profile.lastName": names[names.length - 1]
+    }
+  }, {
+    returnOriginal: false
+  });
+
+  await appEvents.emit("afterAccountUpdate", {
+    account: updatedAccount,
+    updatedBy: accountId,
+    updatedFields: ["profile.name", "profile.firstName", "profile.lastName"]
+  });
+
+  return updatedAccount;
+}

--- a/imports/node-app/core-services/account/resolvers/Mutation/index.js
+++ b/imports/node-app/core-services/account/resolvers/Mutation/index.js
@@ -8,6 +8,7 @@ import sendResetAccountPasswordEmail from "./sendResetAccountPasswordEmail.js";
 import setAccountProfileCurrency from "./setAccountProfileCurrency.js";
 import setAccountProfileLanguage from "./setAccountProfileLanguage.js";
 import updateAccountAddressBookEntry from "./updateAccountAddressBookEntry.js";
+import updateAccountName from "./updateAccountName";
 
 export default {
   addAccountAddressBookEntry,
@@ -19,5 +20,6 @@ export default {
   sendResetAccountPasswordEmail,
   setAccountProfileCurrency,
   setAccountProfileLanguage,
-  updateAccountAddressBookEntry
+  updateAccountAddressBookEntry,
+  updateAccountName
 };

--- a/imports/node-app/core-services/account/resolvers/Mutation/updateAccountName.js
+++ b/imports/node-app/core-services/account/resolvers/Mutation/updateAccountName.js
@@ -1,0 +1,29 @@
+import { decodeAccountOpaqueId } from "@reactioncommerce/reaction-graphql-xforms/account";
+
+/**
+ * @name Mutation/updateAccountName
+ * @method
+ * @memberof Accounts/GraphQL
+ * @summary resolver for the updateAccountName GraphQL mutation
+ * @param {Object} _ - unused
+ * @param {Object} args.input - an object of all mutation arguments that were sent by the client
+ * @param {String} [args.input.accountId] - The account ID, which defaults to the viewer account
+ * @param {String} args.input.name - The name to update on the viewer
+ * @param {String} [args.input.clientMutationId] - An optional string identifying the mutation call
+ * @param {Object} context - an object containing the per-request state
+ * @returns {Object} updateAccountName
+ */
+export default async function updateAccountName(_, { input }, context) {
+  const { accountId, name, clientMutationId = null } = input;
+  const decodedAccountId = decodeAccountOpaqueId(accountId);
+
+  const updatedAccount = await context.mutations.updateAccountName(context, {
+    name,
+    accountId: decodedAccountId
+  });
+
+  return {
+    account: updatedAccount,
+    clientMutationId
+  };
+}

--- a/imports/node-app/core-services/account/resolvers/Mutation/updateAccountName.js
+++ b/imports/node-app/core-services/account/resolvers/Mutation/updateAccountName.js
@@ -8,17 +8,19 @@ import { decodeAccountOpaqueId } from "@reactioncommerce/reaction-graphql-xforms
  * @param {Object} _ - unused
  * @param {Object} args.input - an object of all mutation arguments that were sent by the client
  * @param {String} [args.input.accountId] - The account ID, which defaults to the viewer account
- * @param {String} args.input.name - The name to update on the viewer
+ * @param {String} args.input.firstName - The first name to update on the viewer
+ * @param {String} args.input.lastName - The last name to update on the viewer
  * @param {String} [args.input.clientMutationId] - An optional string identifying the mutation call
  * @param {Object} context - an object containing the per-request state
  * @returns {Object} updateAccountName
  */
 export default async function updateAccountName(_, { input }, context) {
-  const { accountId, name, clientMutationId = null } = input;
+  const { accountId, firstName, lastName, clientMutationId = null } = input;
   const decodedAccountId = decodeAccountOpaqueId(accountId);
 
   const updatedAccount = await context.mutations.updateAccountName(context, {
-    name,
+    firstName,
+    lastName,
     accountId: decodedAccountId
   });
 

--- a/imports/node-app/core-services/account/resolvers/Mutation/updateAccountName.test.js
+++ b/imports/node-app/core-services/account/resolvers/Mutation/updateAccountName.test.js
@@ -6,23 +6,25 @@ mockContext.mutations.updateAccountName = jest.fn().mockName("mutations.updateAc
 
 test("correctly passes through to internal mutation function", async () => {
   const accountId = encodeAccountOpaqueId("1");
-  const name = "Test User Name";
+  const firstName = "Test";
+  const lastName = "Name";
 
-  const fakeResult = { _id: "1", profile: { name: "Test User Name", firstName: "Test", lastName: "Name" } };
+  const fakeResult = { _id: "1", profile: { name: "Test Name", firstName: "Test", lastName: "Name" } };
 
   mockContext.mutations.updateAccountName.mockReturnValueOnce(Promise.resolve(fakeResult));
 
   const result = await updateAccountName(null, {
     input: {
       accountId,
-      name,
+      firstName,
+      lastName,
       clientMutationId: "clientMutationId"
     }
   }, mockContext);
 
   expect(mockContext.mutations.updateAccountName).toHaveBeenCalledWith(
     mockContext,
-    { accountId: "1", name: "Test User Name" }
+    { accountId: "1", firstName: "Test", lastName: "Name" }
   );
 
   expect(result).toEqual({

--- a/imports/node-app/core-services/account/resolvers/Mutation/updateAccountName.test.js
+++ b/imports/node-app/core-services/account/resolvers/Mutation/updateAccountName.test.js
@@ -1,0 +1,32 @@
+import { encodeAccountOpaqueId } from "@reactioncommerce/reaction-graphql-xforms/account";
+import mockContext from "@reactioncommerce/api-utils/tests/mockContext.js";
+import updateAccountName from "./updateAccountName.js";
+
+mockContext.mutations.updateAccountName = jest.fn().mockName("mutations.updateAccountName");
+
+test("correctly passes through to internal mutation function", async () => {
+  const accountId = encodeAccountOpaqueId("1");
+  const name = "Test User Name";
+
+  const fakeResult = { _id: "1", profile: { name: "Test User Name", firstName: "Test", lastName: "Name" } };
+
+  mockContext.mutations.updateAccountName.mockReturnValueOnce(Promise.resolve(fakeResult));
+
+  const result = await updateAccountName(null, {
+    input: {
+      accountId,
+      name,
+      clientMutationId: "clientMutationId"
+    }
+  }, mockContext);
+
+  expect(mockContext.mutations.updateAccountName).toHaveBeenCalledWith(
+    mockContext,
+    { accountId: "1", name: "Test User Name" }
+  );
+
+  expect(result).toEqual({
+    account: fakeResult,
+    clientMutationId: "clientMutationId"
+  });
+});

--- a/imports/node-app/core-services/account/schemas/account.graphql
+++ b/imports/node-app/core-services/account/schemas/account.graphql
@@ -139,6 +139,18 @@ input RemoveAccountEmailRecordInput {
   email: Email!
 }
 
+"Describes an account profile name change"
+input UpdateAccountNameInput {
+  "The account ID, which defaults to the viewer account"
+  accountId: ID
+
+  "An optional string identifying the mutation call, which will be returned in the response payload"
+  clientMutationId: String
+
+  "The name to set on the account"
+  name: String!
+}
+
 "Per-account tax exemption settings used by the Avalara plugin"
 type TaxSettings {
   "Customer usage type. A value matching the `code` field of one TaxEntityCode, or any custom string."
@@ -352,6 +364,15 @@ type SetAccountProfileLanguagePayload {
   clientMutationId: String
 }
 
+"The response from the `updateAccountName` mutation"
+type UpdateAccountNamePayload {
+  "The updated account"
+  account: Account
+
+  "The same string you sent with the mutation params, for matching mutation calls with their responses"
+  clientMutationId: String
+}
+
 extend type Shop {
   """
   Returns a list of administrators for this shop, as a Relay-compatible connection.
@@ -432,6 +453,12 @@ extend type Mutation {
     "Mutation input"
     input: UpdateAccountAddressBookEntryInput!
   ): UpdateAccountAddressBookEntryPayload
+
+  "Set the preferred name for an account"
+  updateAccountName(
+    "Mutation input"
+    input: UpdateAccountNameInput!
+  ): UpdateAccountNamePayload
 }
 
 extend type Query {

--- a/imports/node-app/core-services/account/schemas/account.graphql
+++ b/imports/node-app/core-services/account/schemas/account.graphql
@@ -147,8 +147,11 @@ input UpdateAccountNameInput {
   "An optional string identifying the mutation call, which will be returned in the response payload"
   clientMutationId: String
 
-  "The name to set on the account"
-  name: String!
+  "The first name to set on the account"
+  firstName: String!
+
+  "The last name to set on the account"
+  lastName: String!
 }
 
 "Per-account tax exemption settings used by the Avalara plugin"
@@ -454,7 +457,7 @@ extend type Mutation {
     input: UpdateAccountAddressBookEntryInput!
   ): UpdateAccountAddressBookEntryPayload
 
-  "Set the preferred name for an account"
+  "Set the name for an account"
   updateAccountName(
     "Mutation input"
     input: UpdateAccountNameInput!

--- a/imports/plugins/core/tags/client/components/TagDataTable.js
+++ b/imports/plugins/core/tags/client/components/TagDataTable.js
@@ -390,14 +390,13 @@ class TagDataTable extends Component {
    * @returns {undefined} No return value
    */
   handleToggleSelection = (key, shift, row) => {
+    const selectedKey = key.replace("select-", "");
     // update the state
     this.setState((prevState) => {
       // start off with the existing state
       let selection = [...prevState.selection];
-      // let selectedObjects = { ...prevState.selectedObjects }
 
-      const keyIndex = selection.findIndex((element) => element._id === key);
-
+      const keyIndex = selection.findIndex((element) => element._id === selectedKey);
       // check to see if the key exists
       if (keyIndex >= 0) {
         // it does exist so we will remove it using destructing

--- a/package-lock.json
+++ b/package-lock.json
@@ -8703,7 +8703,8 @@
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -8727,13 +8728,15 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -8743,19 +8746,22 @@
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
           "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -8876,7 +8882,8 @@
           "version": "2.0.3",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -8890,6 +8897,7 @@
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -8906,6 +8914,7 @@
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -8914,7 +8923,8 @@
           "version": "0.0.8",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
@@ -8938,6 +8948,7 @@
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -9026,7 +9037,8 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -9040,6 +9052,7 @@
           "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -9176,6 +9189,7 @@
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -9197,6 +9211,7 @@
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -9229,6 +9244,7 @@
               "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
               "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
               "dev": true,
+              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -9248,13 +9264,15 @@
               "version": "5.1.2",
               "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
               "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "yallist": {
               "version": "3.0.3",
               "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
               "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
-              "dev": true
+              "dev": true,
+              "optional": true
             }
           }
         },
@@ -9279,7 +9297,8 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
           "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
@@ -11681,7 +11700,8 @@
             "ansi-regex": {
               "version": "2.1.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -11702,12 +11722,14 @@
             "balanced-match": {
               "version": "1.0.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -11722,17 +11744,20 @@
             "code-point-at": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "concat-map": {
               "version": "0.0.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "console-control-strings": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -11849,7 +11874,8 @@
             "inherits": {
               "version": "2.0.3",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "ini": {
               "version": "1.3.5",
@@ -11861,6 +11887,7 @@
               "version": "1.0.0",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -11875,6 +11902,7 @@
               "version": "3.0.4",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
@@ -11882,12 +11910,14 @@
             "minimist": {
               "version": "0.0.8",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "minipass": {
               "version": "2.3.5",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -11906,6 +11936,7 @@
               "version": "0.5.1",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -11986,7 +12017,8 @@
             "number-is-nan": {
               "version": "1.0.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -11998,6 +12030,7 @@
               "version": "1.4.0",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -12083,7 +12116,8 @@
             "safe-buffer": {
               "version": "5.1.2",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -12119,6 +12153,7 @@
               "version": "1.0.2",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -12138,6 +12173,7 @@
               "version": "3.0.1",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -12181,12 +12217,14 @@
             "wrappy": {
               "version": "1.0.2",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "yallist": {
               "version": "3.0.3",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             }
           }
         },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "reaction",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "reaction",
   "description": "Reaction is a modern reactive, real-time event driven ecommerce platform.",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "main": "main.js",
   "directories": {
     "test": "tests"


### PR DESCRIPTION
Resolves #4646   
Impact: **minor**  
Type: **feature**

## Issue
[#4646](https://github.com/reactioncommerce/reaction/issues/4646)

## Solution
This PR adds a mutation called `updateAccountName` that takes in a name and splits it into firstName and lastName.

It then updates the fields: `name`, `firstName` and `lastName` and can be verified by calling the `viewer` query to ensure that the details are indeed updated.

## Breaking changes
None

## Testing
1. Open up the graphql playground by navigating to `/graphql-beta`
2. Type in the `updateAccountName` mutation and pass in the input object required. See below for example: 
```
mutation updateAccountName($accountId: ID!) {
  updateAccountName(input: {
    accountId: $accountId,
    name: "Test Name Last"
  }) {
    account {
      _id
    name
    firstName
    lastName
    primaryEmailAddress
    }
  }
}
```
3. The mutation should resolve successfully after having updated the name. The expected result should be something similar to the this:
```
{
  "data": {
    "updateAccountName": {
      "account": {
        "_id": "cmVhY3Rpb24vYWNjb3VudDozWjhqTW4zQmJkS0Z5cGFpRA==",
        "name": "Test Name Last",
        "firstName": "Test",
        "lastName": "Last",
        "primaryEmailAddress": "test.user@gmail.com"
      }
    }
  }
}
```